### PR TITLE
Add way to list servers filtered by name

### DIFF
--- a/scripts/openstack.js
+++ b/scripts/openstack.js
@@ -118,7 +118,33 @@ module.exports = function(robot) {
         });
     });
 
-    robot.respond(/openstack-compute servers/i, function(msg) {
+    robot.respond(/openstack-compute servers (.+)/i, function(msg) {
+        if (!computeValidate(msg)) {
+            return;
+        }
+
+        regexp_pattern = msg.match[1]
+        regexp = new RegExp(regexp_pattern, "gi")
+
+        computeClient().getServers(function(err, data) {
+            if (err) {
+                msg.reply(err);
+                return;
+            }
+
+            var servers = '';
+            data.forEach(function(server) {
+                if (server.name.match(regexp)) {
+                    console.log(server);
+                    servers += '• ' + computeServerInfo(server);
+                }
+            });
+            msg.reply(servers);
+
+        });
+    });
+
+    robot.respond(/openstack-compute servers$/i, function(msg) {
         if (!computeValidate(msg)) {
             return;
         }


### PR DESCRIPTION
Adds `openstack-compute servers <regexp>`.

E.g.:

```
devopsbot> @devopsbot: openstack-compute servers svysvc
• mt1-svysvc102 / 10.128.40.146: RUNNING, key_pair: master, tenant: a5920c8f7bf6441a9e2e96eb7b62d1d5,  4 months ago
• mt5-svysvc101 / 10.128.40.101: RUNNING, key_pair: master, tenant: a5920c8f7bf6441a9e2e96eb7b62d1d5,  7 months ago
• mt4-svysvc101 / 10.128.40.100: RUNNING, key_pair: master, tenant: a5920c8f7bf6441a9e2e96eb7b62d1d5,  7 months ago
• mt3-svysvc101 / 10.128.40.98: RUNNING, key_pair: master, tenant: a5920c8f7bf6441a9e2e96eb7b62d1d5,  7 months ago
• mt2-svysvc101 / 10.128.40.97: RUNNING, key_pair: master, tenant: a5920c8f7bf6441a9e2e96eb7b62d1d5,  7 months ago
```
