### PR TITLE
Display server id for other server operations

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -2,7 +2,7 @@ fs = require 'fs'
 path = require 'path'
 
 module.exports = (robot, scripts) ->
-  scriptsPath = path.resolve(__dirname, 'src')
+  scriptsPath = path.resolve(__dirname, 'scripts')
   fs.exists scriptsPath, (exists) ->
     if exists
       for script in fs.readdirSync(scriptsPath)

--- a/scripts/openstack.js
+++ b/scripts/openstack.js
@@ -76,6 +76,7 @@ var
         return server.name +
             ' / ' + server.addresses.private +
             ': ' + server.status +
+            ', id: ' + server.id +
             ', key_pair: ' + server.openstack.key_name +
             ', tenant: ' + server.openstack.tenant_id +
             ',  ' + moment(server.created).fromNow() + '\n';


### PR DESCRIPTION
For other server operations dependent on server id instead of name , this will be useful.
Also i have added the path change for scripts in index.coffee
